### PR TITLE
chore: refactored the colab notebook.

### DIFF
--- a/notebooks/TF_to_ONNX.ipynb
+++ b/notebooks/TF_to_ONNX.ipynb
@@ -6,9 +6,9 @@
         "id": "ahaLOgxyzACW"
       },
       "source": [
-        "# Convert tf.keras model to ONNX\n",
+        "# Convert `tf.keras` model to ONNX\n",
         "\n",
-        "This tutorial shows \n",
+        "This tutorial shows:\n",
         "- how to convert tf.keras model to ONNX from the saved model file or the source code directly. \n",
         "- comparison of the execution time of the inference on CPU between tf.keras model and ONNX converted model."
       ]
@@ -26,11 +26,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
-        "id": "Y7VIFntKUh0R"
+        "id": "Y7VIFntKUh0R",
+        "outputId": "2a14821e-0096-45c3-8e97-81c28e00d43d",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[K     |████████████████████████████████| 435 kB 13.5 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 12.8 MB 62.5 MB/s \n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "tensorflow 2.8.0 requires tf-estimator-nightly==2.8.0.dev2021122109, which is not installed.\u001b[0m\n",
+            "\u001b[K     |████████████████████████████████| 4.9 MB 12.6 MB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ],
       "source": [
         "!pip install -Uqq tf2onnx\n",
         "!pip install -Uqq onnxruntime"
@@ -47,7 +64,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "metadata": {
         "id": "-UfszPPVf9P0"
       },
@@ -70,11 +87,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 3,
       "metadata": {
-        "id": "3R81akF_hDEL"
+        "id": "3R81akF_hDEL",
+        "outputId": "c1078b0a-de22-449d-f3a6-9586bc26ba0d",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading data from https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50_weights_tf_dim_ordering_tf_kernels.h5\n",
+            "102973440/102967424 [==============================] - 0s 0us/step\n",
+            "102981632/102967424 [==============================] - 0s 0us/step\n"
+          ]
+        }
+      ],
       "source": [
         "core = tf.keras.applications.ResNet50(include_top=True, input_shape=(224, 224, 3))\n",
         "\n",
@@ -83,6 +114,16 @@
         "outputs = core(preprocess, training=False)\n",
         "model = tf.keras.Model(inputs=[inputs], outputs=[outputs])"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that we are including the preprocessing layer in the `model` object. This will allow us to load an image from disk and run the model directly without requiring any\n",
+        "model-specific preprocessing. This reduces training/serving skew. "
+      ],
+      "metadata": {
+        "id": "W3smmoIBCFOX"
+      }
     },
     {
       "cell_type": "markdown",
@@ -95,18 +136,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "3-friv_fMk79",
-        "outputId": "b25b7903-cac8-4c84-d4f5-81e83f8013db"
+        "outputId": "e8b42513-0ca5-4d24-8986-03a2281dd93b"
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "first layer name: image_input\n",
             "last layer name: resnet50\n"
@@ -127,26 +168,40 @@
       "source": [
         "### Conversion\n",
         "\n",
-        "`opset` in `tf2onnx.convert.from_keras` is the ONNX Op version. You can find the full list which TF Ops are convertible to ONNX Ops [[here](https://github.com/onnx/tensorflow-onnx/blob/master/support_status.md)].\n",
+        "`opset` in `tf2onnx.convert.from_keras` is the ONNX Op version. You can find the full list which TensorFlow (TF) Ops are convertible to ONNX Ops [here](https://github.com/onnx/tensorflow-onnx/blob/master/support_status.md).\n",
         "\n",
-        "there are two ways to convert TensorFlow model to ONNX\n",
+        "There are two ways to convert TensorFlow model to ONNX:\n",
         "- `tf2onnx.convert.from_keras` to convert programatically\n",
         "- `tf2onnx.convert` CLI to convert a saved TensorFlow model"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 5,
       "metadata": {
-        "id": "_MAEoy9j0QRQ"
+        "id": "_MAEoy9j0QRQ",
+        "outputId": "daa393dd-7687-474c-a42a-16b450e01e82",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tf2onnx/tf_loader.py:706: extract_sub_graph (from tensorflow.python.framework.graph_util_impl) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.compat.v1.graph_util.extract_sub_graph`\n"
+          ]
+        }
+      ],
       "source": [
         "import onnx\n",
         "\n",
         "input_signature = [tf.TensorSpec([None, 224, 224, 3], tf.float32, name='image_input')]\n",
         "onnx_model, _ = tf2onnx.convert.from_keras(model, input_signature, opset=15)\n",
-        "onnx.save(onnx_model, \"my_model.onnx\")\n",
+        "onnx.save(onnx_model, \"resnet50_w_preprocessing.onnx\")\n",
         "\n",
         "# model.save('my_model')\n",
         "# !python -m tf2onnx.convert --saved-model my_model --output my_model.onnx"
@@ -172,7 +227,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 6,
       "metadata": {
         "id": "ceqZH2KbPznx"
       },
@@ -192,20 +247,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "zL8Lw9H8QbT7",
-        "outputId": "0d3017b3-a9e9-4ff9-9246-73a33fd1f4aa"
+        "outputId": "ca8da3f4-ca00-45dd-a55e-72bfe7ae19e9"
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "1 loop, best of 5: 4.32 s per loop\n"
+            "1 loop, best of 5: 3.41 s per loop\n"
           ]
         }
       ],
@@ -216,42 +271,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 8,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "smFa5VWjTNLb",
-        "outputId": "1565f632-0b01-4079-838c-6d6f8ec867e4"
+        "id": "smFa5VWjTNLb"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[3.15686048e-05 3.87393957e-04 1.79542520e-04 ... 1.30086582e-05\n",
-            "  9.79110773e-05 3.81577667e-03]\n",
-            " [3.48336362e-05 4.16526280e-04 1.93989443e-04 ... 1.55881808e-05\n",
-            "  1.13529946e-04 4.16510738e-03]\n",
-            " [3.33409043e-05 4.33546113e-04 1.97361689e-04 ... 1.53988676e-05\n",
-            "  1.12037051e-04 4.24840674e-03]\n",
-            " ...\n",
-            " [2.89980180e-05 3.86187923e-04 1.73962238e-04 ... 1.27737330e-05\n",
-            "  1.00923535e-04 4.02137777e-03]\n",
-            " [3.22057713e-05 3.88624350e-04 1.79953189e-04 ... 1.43914149e-05\n",
-            "  1.02170088e-04 3.93211702e-03]\n",
-            " [3.32495474e-05 4.18914686e-04 1.89737257e-04 ... 1.49391553e-05\n",
-            "  1.15772651e-04 4.33536153e-03]]\n",
-            "tf.Tensor(\n",
-            "[664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664\n",
-            " 851 664 664 664 664 664 664 851 664 664 664 664 664 664], shape=(32,), dtype=int64)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "tf_preds = model.predict(dummy_inputs)\n",
-        "print(tf_preds)\n",
-        "print(tf.argmax(tf_preds, axis=1))"
+        "tf_preds = model.predict(dummy_inputs)"
       ]
     },
     {
@@ -269,7 +295,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 10,
       "metadata": {
         "id": "1ELVBwrn0-Cf"
       },
@@ -278,26 +304,26 @@
         "import onnxruntime as ort\n",
         "import numpy as np\n",
         "\n",
-        "sess = ort.InferenceSession(\"my_model.onnx\") # providers=[\"CUDAExecutionProvider\"])\n",
+        "sess = ort.InferenceSession(\"resnet50_w_preprocessing.onnx\") # providers=[\"CUDAExecutionProvider\"])\n",
         "np_dummy_inputs = dummy_inputs.numpy()"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "jszhyR15SJaE",
-        "outputId": "fd9d4ce6-ec46-4b9d-f699-d6764d3640eb"
+        "outputId": "6220cb91-4aac-41c9-cf2f-caac3ed98ee5"
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "1 loop, best of 5: 3.64 s per loop\n"
+            "1 loop, best of 5: 3.06 s per loop\n"
           ]
         }
       ],
@@ -308,42 +334,34 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 12,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Ax6opk4ENmlK",
-        "outputId": "18ec2dee-af04-42f9-bebc-13043ae787d3"
+        "id": "Ax6opk4ENmlK"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[array([[3.1568543e-05, 3.8739358e-04, 1.7954242e-04, ..., 1.3008658e-05,\n",
-            "        9.7910888e-05, 3.8157741e-03],\n",
-            "       [3.4834065e-05, 4.1653065e-04, 1.9399117e-04, ..., 1.5588314e-05,\n",
-            "        1.1353097e-04, 4.1651078e-03],\n",
-            "       [3.3341144e-05, 4.3354733e-04, 1.9736330e-04, ..., 1.5398955e-05,\n",
-            "        1.1203749e-04, 4.2484212e-03],\n",
-            "       ...,\n",
-            "       [2.8998174e-05, 3.8618816e-04, 1.7396275e-04, ..., 1.2773765e-05,\n",
-            "        1.0092379e-04, 4.0213722e-03],\n",
-            "       [3.2205990e-05, 3.8862476e-04, 1.7995379e-04, ..., 1.4391498e-05,\n",
-            "        1.0217058e-04, 3.9321054e-03],\n",
-            "       [3.3249766e-05, 4.1891521e-04, 1.8973851e-04, ..., 1.4939254e-05,\n",
-            "        1.1577292e-04, 4.3353694e-03]], dtype=float32)]\n",
-            "[664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664 664\n",
-            " 851 664 664 664 664 664 664 851 664 664 664 664 664 664]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "ort_preds = sess.run(None, {\"image_input\": np_dummy_inputs})\n",
-        "print(ort_preds)\n",
-        "print(np.argmax(ort_preds[0], axis=1))"
+        "ort_preds = sess.run(None, {\"image_input\": np_dummy_inputs})"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Check if the TF and ONNX outputs match"
+      ],
+      "metadata": {
+        "id": "jbrwQMDbBLps"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "np.testing.assert_allclose(tf_preds, ort_preds[0], atol=1e-4)"
+      ],
+      "metadata": {
+        "id": "um99Uu4FBPrY"
+      },
+      "execution_count": 16,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -353,20 +371,11 @@
       "source": [
         "## Conclusion\n",
         "\n",
-        "We did a simple experiments with dummy dataset of 32 batch size. The default behaviour of `timeit` is to measure the average of the cell execution time with 7 times of repeat ([`timeit`'s default behaviour](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-timeit))\n",
+        "We did a simple experiments with dummy dataset of 32 batch size. The default behaviour of `timeit` is to measure the average of the cell execution time with 7 times of repeat ([`timeit`'s default behaviour](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-timeit)).\n",
         "\n",
         "\n",
-        "The TF implementation of the ResNet50 took about 4.32s while the ONNX converted model took about 3.64s on average for the the inference job. So it is clear ONNX converted model is much faster on CPU."
+        "The ONNX model will likely always have a better inference latency than the TF model if you are using a CPU server for inference."
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XXx5Mr2VWobP"
-      },
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
Just added a text cell explaining why it's better to include the preprocessing function in the final exported model. Also, added a cell to show if the TF and ONNX outputs match with `np.testing.assert_allclose()`. 